### PR TITLE
update Initialize struct to require mutable merkle_tree account

### DIFF
--- a/account-compression/programs/account-compression/src/lib.rs
+++ b/account-compression/programs/account-compression/src/lib.rs
@@ -76,8 +76,8 @@ security_txt! {
 /// Context for initializing a new SPL ConcurrentMerkleTree
 #[derive(Accounts)]
 pub struct Initialize<'info> {
-    // #[account(zero)]
     /// CHECK: This account will be zeroed out, and the size will be validated
+    #[account(mut)]
     pub merkle_tree: UncheckedAccount<'info>,
 
     /// Authority that controls write-access to the tree


### PR DESCRIPTION
Had an issue while using CPI to initialize merkle tree which is required to be mutable but wasn't specified